### PR TITLE
feat(dev): add Docker Compose for Postgres and update Quick Start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ cp UnsecuredAPIKeys.Bots.Verifier/appsettings.example.json UnsecuredAPIKeys.Bots
 ```
 
 ### 3. Start the Database
+
+**Option A: Docker Compose (recommended for dev)**
+```bash
+docker compose up -d db
+```
+
+**Option B: One-off container**
 ```bash
 docker run --name unsecured-api-keys-db \
   -e POSTGRES_DB=UnsecuredAPIKeys \
@@ -86,6 +93,15 @@ docker run --name unsecured-api-keys-db \
   -e POSTGRES_PASSWORD=your_password \
   -p 5432:5432 \
   -d postgres:15
+```
+
+### Stopping the database
+```bash
+docker compose down
+```
+To also remove the dev volume:
+```bash
+docker compose down -v
 ```
 
 ### 4. Run Database Migrations
@@ -119,6 +135,7 @@ dotnet run
 - **UI**: http://localhost:3000
 - **API**: http://localhost:7227
 - **API Documentation**: http://localhost:7227/scalar/v1
+
 
 ## 📚 Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    container_name: unsecuredapikeys-db
+    environment:
+      POSTGRES_DB: UnsecuredAPIKeys
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d UnsecuredAPIKeys"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  dbdata:


### PR DESCRIPTION
This PR introduces a minimal `docker-compose.yml` for local Postgres 15 and updates the Quick Start docs to prefer `docker compose` over a one-off `docker run`.

---

### ✅ What’s included
- New `docker-compose.yml` with a `db` service:
  - Postgres 15
  - Dev-friendly credentials
  - Persistent named volume
  - Healthcheck for service readiness
- `README.md` updates:
  - Option A (Docker Compose, recommended)
  - Option B (one-off container, original method preserved)
  - Notes for stopping and cleaning up the database

---

### 💡 Why
- Simplifies onboarding for contributors — one command to start Postgres
- Keeps backwards compatibility (existing `docker run` instructions remain)
- No changes to how the API, UI, or Verifier bot run locally
- Connection strings and app startup remain the same

---

### 🛠 How to use
```bash
# Start Postgres
docker compose up -d db

# Apply migrations (unchanged)
cd UnsecuredAPIKeys.WebAPI
dotnet ef database update --project ../UnsecuredAPIKeys.Data --startup-project .

# Run apps (unchanged)

# API
cd UnsecuredAPIKeys.WebAPI && dotnet run

# UI
cd ../UnsecuredAPIKeys.UI && npm install && npm run dev

# Verifier Bot
cd ../UnsecuredAPIKeys.Bots.Verifier && dotnet run
```

**Default endpoints:**
- UI → http://localhost:3000  
- API → http://localhost:7227  
- API Docs → http://localhost:7227/scalar/v1

---

### 📌 Notes
- `docker compose down` will stop the database.
- Use `docker compose down -v` if you also want to remove the persistent volume.
- If there’s an open issue requesting Dockerized Postgres, this PR addresses it (add `Closes #<issue-number>` in the PR footer).
